### PR TITLE
fix: update SkillsPreview layout handling and make certification fields optional

### DIFF
--- a/src/components/preview/skills.tsx
+++ b/src/components/preview/skills.tsx
@@ -16,6 +16,14 @@ export const SkillsPreview: React.FC = () => {
     return null;
   }
 
+  const isGridLayout = skillsLayout !== "inline";
+  const gridTemplateStyles =
+    skillsLayout === "grid-col"
+      ? { gridTemplateColumns: `repeat(${skills.length}, minmax(0, 1fr))` }
+      : skillsLayout === "grid-row"
+      ? { gridTemplateRows: `repeat(${skills.length}, minmax(0, 1fr))` }
+      : {};
+
   return (
     <section>
       <h3
@@ -28,13 +36,10 @@ export const SkillsPreview: React.FC = () => {
       <div
         style={{
           lineHeight: `${lineHeight * 0.25}rem`,
+          ...gridTemplateStyles,
         }}
         className={cn("gap-4", {
-          grid: skillsLayout !== "inline",
-          "grid-cols-[repeat(auto-fit,minmax(0,1fr))]":
-            skillsLayout === "grid-col",
-          "grid-rows-[repeat(auto-fit,minmax(0,1fr))]":
-            skillsLayout === "grid-row",
+          grid: isGridLayout,
         })}
       >
         {skillsLayout === "inline" ? (

--- a/src/components/sections/dialogs/certifications.tsx
+++ b/src/components/sections/dialogs/certifications.tsx
@@ -26,8 +26,8 @@ import { RichTextEditor } from "../../core/RichTextEditor";
 
 // define certifications schema
 const certificationSchema = z.object({
-  name: z.string().trim().min(1, { message: "Name is required" }),
-  issuer: z.string().trim().min(1, { message: "Issuer is required" }),
+  name: z.string().trim().optional(), // make optional
+  issuer: z.string().trim().optional(), // make optional
   date: z.string().trim(),
   website: z.literal("").or(z.string().url()),
   summary: z.string().trim(),
@@ -84,6 +84,8 @@ export const CertificationsDialog: React.FC = () => {
 
   useEffect(() => {
     form.reset(defaultValues);
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [index, certifications]);
 
   return (


### PR DESCRIPTION

- Refactor SkillsPreview to improve grid layout handling based on skillsLayout prop
- Make 'name' and 'issuer' fields in the certification schema optional for better flexibility