### PR TITLE
feat(section): add per-item hide from PDF and consolidate actions into dropdown menu Description

### DIFF
--- a/.opencode/context.md
+++ b/.opencode/context.md
@@ -1,0 +1,362 @@
+# CV Master - Persistent Context
+
+## Data Flow Diagrams
+
+### Import PDF Flow
+```
+User uploads PDF
+    ↓
+useImportPDF hook validates file (type, size 1KB-20MB)
+    ↓
+PDF.js extracts text (client-side, loaded from CDN)
+    ↓
+Text sent to Groq API → generateJSONFromText()
+    ↓
+Model: openai/gpt-oss-120b (JSON response format)
+    ↓
+AI returns structured JSON matching cvMasterSchema
+    ↓
+cleanAIResponse() removes markdown code blocks
+    ↓
+JSON.parse() validates structure
+    ↓
+useResume.setData() updates resumeData
+    ↓
+usePdfSettings.setValue() updates pdfSettings (font, spacing, margins)
+    ↓
+localStorage synced automatically
+```
+
+### Import Image Flow
+```
+User uploads image (PNG/JPG/JPEG, max 4MB)
+    ↓
+useImportImage hook validates file
+    ↓
+FileReader converts to base64
+    ↓
+Base64 sent to Groq Vision API → generateJSONFromImage()
+    ↓
+Model: meta-llama/llama-4-scout-17b-16e-instruct (multimodal)
+    ↓
+AI returns structured JSON
+    ↓
+validateCVData() checks for meaningful CV content
+    ↓
+useResume.setData() updates resumeData
+    ↓
+usePdfSettings.setValue() updates pdfSettings
+    ↓
+localStorage synced automatically
+```
+
+### Export PDF Flow
+```
+User clicks Download button
+    ↓
+DownloadCV component creates hidden div
+    ↓
+createRoot() renders <Page mode="print" /> to div
+    ↓
+getHtmlContent() wraps div.innerHTML in full HTML document
+    ↓
+HTML includes Tailwind CSS CDN + Google Fonts link
+    ↓
+POST to backend /pdf endpoint with { htmlContent, name, title, margin }
+    ↓
+Backend launches Puppeteer (local) or puppeteer-core + Chromium (prod)
+    ↓
+page.setContent() + page.pdf() generates A4 PDF
+    ↓
+PDF buffer uploaded to Cloudinary (folder: "cvs")
+    ↓
+Cloudinary returns secure_url
+    ↓
+Client creates <a> element and triggers download
+```
+
+### AI Review Flow
+```
+User clicks "AI Review" button
+    ↓
+ReviewCvDialog opens, user enters job title + description
+    ↓
+Zod validates inputs (title min 5 chars, description min 100 chars)
+    ↓
+useResume.resumeData serialized to JSON string
+    ↓
+aiReview() sends to Groq API
+    ↓
+Model: openai/gpt-oss-120b (JSON response format)
+    ↓
+AI returns Analysis object with scores, recommendations
+    ↓
+useAnalysis.setAnalysis() stores result
+    ↓
+useAnalysis.setIsAnalyzing(false)
+    ↓
+User navigated to /review page
+    ↓
+ReviewResult component displays analysis in tabs
+```
+
+## Groq AI Model Usage Map
+
+| Function | Model | Temperature | Max Tokens | Use Case |
+|----------|-------|-------------|------------|----------|
+| `improveContent()` | llama-3.1-8b-instant | 0.1 | 1024 | Rewrite text professionally |
+| `fixTypos()` | llama-3.1-8b-instant | 0.1 | 1024 | Fix spelling/grammar |
+| `customizeContent()` | llama-3.1-8b-instant | 0.1 | 1024 | Adjust tone/length |
+| `generateJSONFromText()` | openai/gpt-oss-120b | 1.0 | 8096 | Parse PDF text to JSON |
+| `generateJSONFromImage()` | meta-llama/llama-4-scout-17b-16e-instruct | 1.0 | 8096 | Parse image to JSON (vision) |
+| `aiReview()` | openai/gpt-oss-120b | 0.5 | 8192 | Comprehensive CV review |
+
+**Model Selection Rationale:**
+- `llama-3.1-8b-instant`: Fast, cheap, good for simple text transformations
+- `openai/gpt-oss-120b`: Better at structured JSON output, used for parsing and analysis
+- `meta-llama/llama-4-scout-17b-16e-instruct`: Multimodal (vision), used for image parsing
+
+## Store Structure Details
+
+### useResume Store
+```ts
+{
+  sectionOrder: SectionName[], // Order sections appear in preview
+  resumeData: {
+    basics: Basics, // Personal info, photo, alignment
+    summary: Summary, // Section title + HTML content
+    experience: Experience[], // Work history
+    projects: Project[], // Portfolio projects
+    education: Education[], // Academic background
+    skills: Skill[], // Technical skills with keywords
+    languages: Language[], // Language proficiency
+    certifications: Certification[], // Professional certs
+    awards: Award[], // Achievements
+    volunteering: Volunteering[], // Volunteer work
+    sectionTitles: { [key in SectionName]: string }, // Custom section names
+    pdfSettings: PdfSettings // Rendering settings (embedded in resumeData)
+  },
+  setData: (data: Partial<resumeData>) => void,
+  setSectionOrder: (order: SectionName[]) => void
+}
+```
+
+### usePdfSettings Store
+```ts
+{
+  pdfSettings: {
+    fontSize: number, // 12-18px
+    fontFamily: string, // Google Font name
+    fontCategory: string, // "ATS-Friendly" | "serif" | "sans-serif" | etc.
+    scale: number, // Preview zoom level (0.4-2.0)
+    lineHeight: number, // Tailwind leading-* (4-10)
+    verticalSpacing: number, // Tailwind space-y-* (1-10)
+    margin: { MIN, MAX, VALUE, INITIAL }, // Page margins in px
+    pageBreakLine: boolean, // Show dashed line at page break
+    skillsLayout: "inline" | "grid-col" | "grid-row" // Skills display mode
+  },
+  setValue: (key: string, value: any) => void
+}
+```
+
+### useAnalysis Store
+```ts
+{
+  currentAnalysis: Analysis | null, // Last AI review result
+  isAnalyzing: boolean, // Loading state
+  error: string | null, // Error message
+  setAnalysis: (analysis: Analysis) => void,
+  setIsAnalyzing: (isAnalyzing: boolean) => void,
+  clearAnalysis: () => void,
+  setError: (error: string | null) => void
+}
+```
+
+## localStorage Key Mapping
+
+| Key | Store | Type | Description |
+|-----|-------|------|-------------|
+| `resumeData` | useResume | JSON | Full resume data object |
+| `pdfSetting` | usePdfSettings | JSON | PDF rendering settings (note: singular) |
+| `sectionOrder` | useResume | JSON | `{ sectionOrder: SectionName[] }` |
+| `currentAnalysis` | useAnalysis | JSON | Last AI review Analysis object |
+| `cv-master-theme` | ThemeProvider | string | "dark" \| "light" \| "system" |
+| `hasVisited` | sessionStorage | string | "true" after first visit (for loader) |
+
+## Component Hierarchy
+
+### App Structure
+```
+<BrowserRouter>
+  <Routes>
+    <Route path="/" element={<App />} />
+    <Route path="/review" element={<ReviewPage />} />
+  </Routes>
+</BrowserRouter>
+
+<App>
+  <ThemeProvider>
+    <DialogProvider>
+      <Header />
+      {isMobile ? <MobileCvTabs /> : (
+        <div>
+          <CvForm />
+          <Preview />
+        </div>
+      )}
+      <Toaster />
+      <Analytics />
+    </DialogProvider>
+  </ThemeProvider>
+</App>
+```
+
+### CvForm Structure
+```
+<CvForm>
+  <SidebarNavigation />
+  <ScrollArea>
+    <BasicsInfo />
+    <SummaryForm />
+    <SectionBase id="experience" />
+    <SectionBase id="projects" />
+    <SectionBase id="education" />
+    <SectionBase id="skills" />
+    <SectionBase id="languages" />
+    <SectionBase id="certifications" />
+    <SectionBase id="awards" />
+    <SectionBase id="volunteering" />
+  </ScrollArea>
+</CvForm>
+```
+
+### Preview Structure
+```
+<Preview>
+  <TransformWrapper>
+    <TransformComponent>
+      <Page mode="preview">
+        <BasicsPreview />
+        {sectionOrder.map(section => (
+          switch(section) {
+            case "summary": <SummaryPreview />
+            case "experience": <ExperiencePreview />
+            // ... other sections
+          }
+        ))}
+      </Page>
+    </TransformComponent>
+    <Controls />
+  </TransformWrapper>
+</Preview>
+```
+
+### Dialog System
+```
+<DialogProvider>
+  {children}
+  {isOpen("experience") && <ExperienceDialog />}
+  {isOpen("projects") && <ProjectsDialog />}
+  {isOpen("education") && <EducationDialog />}
+  {isOpen("skills") && <SkillsDialog />}
+  {isOpen("languages") && <LanguagesDialog />}
+  {isOpen("certifications") && <CertificationsDialog />}
+  {isOpen("awards") && <AwardsDialog />}
+  {isOpen("volunteering") && <VolunteeringDialog />}
+</DialogProvider>
+```
+
+## Key TypeScript Types
+
+### Resume Sections
+- `Basics` - Personal info with photo, alignment, custom fields
+- `Summary` - Section title + HTML content
+- `Experience` - Company, position, dateRange, location, employmentType, website, summary
+- `Project` - Name, description, date, website, summary, keywords
+- `Education` - Institution, degree, studyField, date, website, summary
+- `Skill` - Name + keywords array
+- `Language` - Name + level
+- `Certification` / `Award` - Name, date, issuer, website, summary
+- `Volunteering` - Name, position, date, location, summary
+
+### Analysis (AI Review Result)
+```ts
+{
+  overallScore: number, // 0-100
+  jobFitPercentage: number, // 0-100
+  summary: {
+    strengths: string[],
+    weaknesses: string[],
+    fitLevel: "Excellent" | "Good" | "Fair" | "Poor"
+  },
+  detailedAnalysis: {
+    contentAlignment: { score, feedback, matchingSkills, missingSkills },
+    experienceRelevance: { score, feedback, relevantExperience, experienceGaps },
+    resumeStructure: { score, feedback, sectionsToImprove },
+    atsCompatibility: { score, feedback, missingKeywords }
+  },
+  recommendations: { highPriority, mediumPriority, lowPriority },
+  specificImprovements: { professionalSummary, skillsSection, ... },
+  nextSteps: string[],
+  estimatedImprovementTime: string
+}
+```
+
+## Backend API Details
+
+### POST /pdf
+**Request:**
+```json
+{
+  "htmlContent": "<html>...</html>",
+  "name": "John Doe",
+  "title": "Software Engineer",
+  "margin": { "MIN": 10, "MAX": 50, "VALUE": 20, "INITIAL": 20 }
+}
+```
+
+**Response:**
+```json
+{
+  "message": "PDF generated and uploaded successfully",
+  "url": "https://res.cloudinary.com/...",
+  "public_id": "cvs/john-doe_software-engineer_09-06-2026_abc123"
+}
+```
+
+### POST /upload-photo
+**Request:**
+```json
+{
+  "image": "data:image/png;base64,iVBORw0KGgo..."
+}
+```
+
+**Response:**
+```json
+{
+  "url": "https://res.cloudinary.com/..."
+}
+```
+
+**Rate Limit:** 10 requests per 15 minutes per IP
+
+## Vite Build Configuration
+
+**Manual Chunks:**
+- `react-vendor` - React, ReactDOM, React Router
+- `forms` - react-hook-form, Zod, @hookform/resolvers
+- `state` - Zustand
+- `dnd` - @dnd-kit/*
+- `radix` - All @radix-ui/* packages
+- `tiptap` - All @tiptap/* packages
+- `icons` - lucide-react
+- `utils` - qs, dotenv, clsx, cva, tailwind-merge, cmdk, @uidotdev/usehooks
+- `services` - groq-sdk, @vercel/analytics
+
+**Path Alias:** `@/` → `./src/`
+
+**Plugins:**
+- `@vitejs/plugin-react` - React Fast Refresh
+- `rollup-plugin-visualizer` - Bundle analysis (opens stats.html)
+- `vite-plugin-compression` - Gzip compression for assets > 1KB

--- a/.opencode/skills.md
+++ b/.opencode/skills.md
@@ -1,0 +1,1173 @@
+# CV Master - Agent Skills Reference
+
+## Skill 1: Adding a New Resume Section (End-to-End)
+
+This is the most complex pattern in the codebase. Follow these steps exactly when adding a new section.
+
+### Step 1: Define TypeScript Types
+
+**File:** `src/types/types.ts`
+
+```ts
+export interface NewSection {
+  id: string;
+  name: string;
+  description: string;
+  date: string;
+  // ... other fields specific to your section
+}
+```
+
+Add to `SectionName` union type:
+```ts
+export type SectionName =
+  | "basics"
+  | "summary"
+  | "experience"
+  // ... existing sections
+  | "newSection"; // Add your section
+```
+
+Add to `ResumeType` interface:
+```ts
+export interface ResumeType {
+  // ...
+  resumeData: {
+    // ... existing sections
+    newSection: NewSection[];
+  };
+}
+```
+
+### Step 2: Create Zod Schema
+
+**File:** `src/lib/schema.ts`
+
+```ts
+const newSectionSchema = z.object({
+  id: z.string(),
+  name: z.string().trim().min(1, { message: "Name is required" }),
+  description: z.string().trim(),
+  date: z.string().trim(),
+  // ... other fields with validation
+});
+```
+
+Add to `cvMasterSchema`:
+```ts
+export const cvMasterSchema = z.object({
+  // ... existing schemas
+  newSection: z.array(newSectionSchema),
+});
+```
+
+### Step 3: Update Store Defaults
+
+**File:** `src/store/useResume.ts`
+
+```ts
+const DEFAULT_RESUME_DATA = {
+  // ... existing defaults
+  newSection: [],
+  sectionTitles: {
+    // ... existing titles
+    newSection: "New Section",
+  },
+};
+```
+
+Add to `sectionOrder` array:
+```ts
+sectionOrder: [
+  "summary",
+  "experience",
+  // ... existing sections
+  "newSection", // Add your section
+],
+```
+
+### Step 4: Create Dialog Component
+
+**File:** `src/components/sections/dialogs/newSection.tsx`
+
+Follow this exact pattern:
+
+```tsx
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "../../ui/dialog";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "../../ui/form";
+import { Input } from "../../ui/input";
+import { Button } from "../../ui/button";
+import { useDialog } from "../../../hooks/useDialog";
+import { useResume } from "../../../store/useResume";
+import { NewSection } from "../../../types/types";
+import { useEffect } from "react";
+import { RichTextEditor } from "../../core/RichTextEditor";
+
+const newSectionSchema = z.object({
+  name: z.string().trim().min(1, { message: "Name is required" }),
+  description: z.string().trim(),
+  date: z.string().trim(),
+});
+
+export const NewSectionDialog: React.FC = () => {
+  const { isOpen, closeDialog, index } = useDialog();
+  const {
+    setData,
+    resumeData: { newSection },
+  } = useResume();
+
+  const isEditMode = newSection && index !== null && newSection[index];
+
+  const defaultValues: NewSection = isEditMode
+    ? newSection[index]
+    : {
+        id: "",
+        name: "",
+        description: "",
+        date: "",
+      };
+
+  const form = useForm<z.infer<typeof newSectionSchema>>({
+    resolver: zodResolver(newSectionSchema),
+    defaultValues,
+  });
+
+  const onSubmit = (data: z.infer<typeof newSectionSchema>) => {
+    const itemWithId = isEditMode
+      ? { ...data, id: newSection[index].id }
+      : { ...data, id: crypto.randomUUID() };
+
+    const updated = isEditMode
+      ? newSection.map((item, i) => (i === index ? itemWithId : item))
+      : [...newSection, itemWithId];
+
+    setData({ newSection: updated });
+    closeDialog();
+    form.reset();
+  };
+
+  useEffect(() => {
+    form.reset(defaultValues);
+  }, [newSection, index]);
+
+  return (
+    <Dialog open={isOpen("newSection")} onOpenChange={closeDialog}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>
+            {isEditMode ? "Edit New Section" : "Add New Section"}
+          </DialogTitle>
+          <DialogDescription>
+            {isEditMode
+              ? "Edit your new section"
+              : "Add a new section to your resume"}
+          </DialogDescription>
+        </DialogHeader>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+            <div className="grid gap-4 sm:grid-cols-2">
+              <FormField
+                control={form.control}
+                name="name"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Name</FormLabel>
+                    <FormControl>
+                      <Input placeholder="Name" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              {/* ... other fields */}
+              <div className="sm:col-span-2">
+                <FormField
+                  control={form.control}
+                  name="description"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Description</FormLabel>
+                      <FormControl>
+                        <RichTextEditor
+                          content={field.value}
+                          handleChange={field.onChange}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+            </div>
+            <Button type="submit" className="flex w-full sm:w-auto ms-auto">
+              {isEditMode ? "Save Changes" : "Create"}
+            </Button>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+};
+```
+
+### Step 5: Register Dialog in Provider
+
+**File:** `src/providers/DialogProvider.tsx`
+
+```tsx
+import { NewSectionDialog } from "../components/sections/dialogs/newSection";
+
+export const DialogProvider: React.FC<DialogProviderProps> = ({ children }) => {
+  // ... existing code
+  return (
+    <DialogContext.Provider value={...}>
+      {children}
+      {/* ... existing dialogs */}
+      {isOpen("newSection") && <NewSectionDialog />}
+    </DialogContext.Provider>
+  );
+};
+```
+
+### Step 6: Create Preview Component
+
+**File:** `src/components/preview/newSection.tsx`
+
+```tsx
+import { useResume } from "../../store/useResume";
+import { usePdfSettings } from "../../store/useResume";
+
+export const NewSectionPreview: React.FC = () => {
+  const {
+    resumeData: { newSection },
+  } = useResume();
+  const {
+    pdfSettings: { verticalSpacing },
+  } = usePdfSettings();
+
+  if (!newSection || newSection.length === 0) return null;
+
+  return (
+    <section className="space-y-2">
+      <h2 className="text-lg font-bold border-b border-black pb-1">
+        New Section
+      </h2>
+      <div className="space-y-3">
+        {newSection.map((item) => (
+          <div key={item.id}>
+            <div className="flex justify-between">
+              <h3 className="font-semibold">{item.name}</h3>
+              <span className="text-sm">{item.date}</span>
+            </div>
+            <div
+              className="text-sm"
+              dangerouslySetInnerHTML={{ __html: item.description }}
+            />
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+};
+```
+
+### Step 7: Add to Preview Renderer
+
+**File:** `src/components/preview/index.tsx`
+
+```tsx
+import { NewSectionPreview } from "./newSection";
+
+export const Page: React.FC<PreviewProps> = ({ mode }) => {
+  // ... existing code
+  return (
+    <div>
+      <BasicsPreview />
+      {sectionOrder.map((sectionId) => {
+        switch (sectionId) {
+          // ... existing cases
+          case "newSection":
+            return <NewSectionPreview key={sectionId} />;
+          default:
+            return null;
+        }
+      })}
+    </div>
+  );
+};
+```
+
+### Step 8: Add to Form
+
+**File:** `src/components/layout/CvForm.tsx`
+
+```tsx
+<SectionBase
+  id="newSection"
+  name="New Section"
+  itemsCount={resumeData.newSection?.length || 0}
+/>
+```
+
+### Step 9: Add Icon
+
+**File:** `src/components/sections/shared/SectionIcon.tsx`
+
+```tsx
+import { NewIcon } from "lucide-react";
+
+export const SectionIcon: React.FC<{ section: SectionName }> = ({ section }) => {
+  switch (section) {
+    // ... existing cases
+    case "newSection":
+      return <NewIcon className="size-5" />;
+    // ...
+  }
+};
+```
+
+### Step 10: Add to Sidebar Navigation
+
+**File:** `src/components/core/SidebarNavigation.tsx`
+
+```tsx
+<li>
+  <Button
+    title="New Section"
+    variant="ghost"
+    size="icon"
+    className="rounded-full"
+    onClick={scrollIntoView("newSection")}
+  >
+    <SectionIcon section="newSection" />
+  </Button>
+</li>
+```
+
+---
+
+## Skill 2: Groq AI Integration Patterns
+
+### Basic AI Function Structure
+
+**File:** `src/services/groqService.ts`
+
+```ts
+export async function aiFunctionName(input: string) {
+  try {
+    const response = await groq.chat.completions.create({
+      messages: [
+        {
+          role: "system",
+          content: "You are a professional assistant. Your task is to...",
+        },
+        {
+          role: "user",
+          content: `Process the following: ${input}`,
+        },
+      ],
+      model: "llama-3.1-8b-instant", // Choose appropriate model
+      temperature: 0.1, // Low for deterministic, high for creative
+      max_tokens: 1024,
+      top_p: 1,
+      stream: false, // Always false in this codebase
+      stop: null,
+    });
+
+    return response.choices[0]?.message?.content?.trim() || "No response";
+  } catch (error) {
+    console.error("Error:", error);
+    
+    // Handle rate limits
+    if (error instanceof Error && error.message.includes("Rate limit")) {
+      toast({
+        title: "Rate limit exceeded",
+        description: "Please try again later",
+        variant: "destructive",
+      });
+    }
+    
+    return "No response";
+  }
+}
+```
+
+### JSON Response Format (for structured output)
+
+```ts
+const response = await groq.chat.completions.create({
+  messages: [...],
+  model: "openai/gpt-oss-120b", // Better for JSON
+  temperature: 1,
+  max_tokens: 8096,
+  response_format: {
+    type: "json_object", // Forces JSON output
+  },
+});
+
+const content = response.choices[0]?.message?.content?.trim();
+const parsed = JSON.parse(content);
+```
+
+### Vision API (for images)
+
+```ts
+const completion = await groq.chat.completions.create({
+  messages: [
+    {
+      role: "system",
+      content: "You are an image analysis assistant...",
+    },
+    {
+      role: "user",
+      content: [
+        {
+          type: "text",
+          text: "Analyze this image and extract...",
+        },
+        {
+          type: "image_url",
+          image_url: {
+            url: `data:${mimeType};base64,${base64Image}`,
+          },
+        },
+      ],
+    },
+  ],
+  model: "meta-llama/llama-4-scout-17b-16e-instruct", // Multimodal model
+  temperature: 1,
+  max_tokens: 8096,
+});
+```
+
+### Cleaning AI Responses
+
+```ts
+function cleanAIResponse(content: string): string {
+  // Remove markdown code blocks
+  let cleaned = content.replace(/```json\s*/g, "").replace(/```\s*/g, "");
+
+  // Extract JSON object
+  const firstBrace = cleaned.indexOf("{");
+  if (firstBrace !== -1) {
+    cleaned = cleaned.substring(firstBrace);
+  }
+
+  const lastBrace = cleaned.lastIndexOf("}");
+  if (lastBrace !== -1) {
+    cleaned = cleaned.substring(0, lastBrace + 1);
+  }
+
+  return cleaned.trim();
+}
+```
+
+### Error Handling Patterns
+
+```ts
+try {
+  const result = await aiFunction(input);
+  // Process result
+} catch (error) {
+  if (error instanceof Error) {
+    if (error.message.includes("Rate limit")) {
+      throw new Error("AI Model rate limit reached. Please try again later.");
+    } else if (error.message.includes("JSON")) {
+      throw new Error("Invalid data format received from AI");
+    } else if (error.message.includes("network")) {
+      throw new Error("Network error. Please check your connection.");
+    }
+  }
+  throw new Error("AI processing failed. Please try again.");
+}
+```
+
+---
+
+## Skill 3: PDF Generation Flow
+
+### Client-Side (DownloadCV Component)
+
+**File:** `src/components/core/DownloadCV.tsx`
+
+```tsx
+// 1. Create hidden div and render print mode
+const div = document.createElement("div");
+const root = createRoot(div);
+flushSync(() => {
+  root.render(<Page mode="print" />);
+});
+
+// 2. Build full HTML document
+const getHtmlContent = () => {
+  return `<html>
+    <head>
+      <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+      <link href="${buildFontCssUrl(fontFamily, ["400", "700"])}" rel="stylesheet">
+    </head>
+    <style>
+      :root { --resume-font-family: ${fontFamily}; }
+      body { font-family: var(--resume-font-family); }
+      ul { list-style-type: disc; padding-left: 2rem; }
+      ol { list-style-type: decimal; padding-left: 2rem; }
+      a { text-decoration: underline; }
+    </style>
+    <body>
+      ${div.innerHTML}
+    </body>
+  </html>`;
+};
+
+// 3. Send to backend
+const res = await fetch(`${import.meta.env.VITE_BACKEND_URL}/pdf`, {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({
+    htmlContent: getHtmlContent(),
+    name: basics.name,
+    title: basics.title,
+    margin: pdfSettings.margin,
+  }),
+});
+
+// 4. Download from Cloudinary URL
+const data = await res.json();
+const link = document.createElement("a");
+link.href = data.url;
+link.download = `${basics.name}-${basics.title}.pdf`;
+link.click();
+```
+
+### Server-Side (Backend)
+
+**File:** `backend/index.js`
+
+```js
+app.post("/pdf", async (req, res) => {
+  const { htmlContent, name, title, margin } = req.body;
+
+  if (!htmlContent) {
+    return res.status(400).json({ message: "HTML content is required" });
+  }
+
+  try {
+    let browser;
+
+    if (process.env.NODE_ENV === "development") {
+      browser = await puppeteer.launch({
+        headless: true,
+        args: ["--no-sandbox", "--disable-setuid-sandbox"],
+      });
+    }
+
+    if (process.env.NODE_ENV === "production") {
+      browser = await puppeteerCore.launch({
+        args: Chromium.args,
+        defaultViewport: Chromium.defaultViewport,
+        executablePath: await Chromium.executablePath(),
+        headless: Chromium.headless,
+      });
+    }
+
+    const page = await browser.newPage();
+    await page.setContent(htmlContent, { waitUntil: "networkidle0" });
+
+    const pdfBuffer = await page.pdf({
+      format: "a4",
+      printBackground: true,
+      margin: {
+        top: `${margin.VALUE}px`,
+        bottom: `${margin.VALUE}px`,
+        left: `${margin.VALUE}px`,
+        right: `${margin.VALUE}px`,
+      },
+    });
+
+    await browser.close();
+
+    // Upload to Cloudinary
+    const uploadResult = await new Promise((resolve, reject) => {
+      cloudinary.uploader.upload_stream(
+        {
+          resource_type: "image",
+          folder: "cvs",
+          format: "pdf",
+          public_id: `${name}_${title}_${uuid}`,
+        },
+        (error, result) => {
+          if (error) reject(error);
+          else resolve(result);
+        }
+      ).end(pdfBuffer);
+    });
+
+    res.json({
+      message: "PDF generated successfully",
+      url: uploadResult.secure_url,
+      public_id: uploadResult.public_id,
+    });
+  } catch (error) {
+    console.error("PDF generation error:", error);
+    res.status(500).json({ message: "Internal server error" });
+  }
+});
+```
+
+---
+
+## Skill 4: Import Flow Patterns
+
+### PDF Import
+
+**File:** `src/hooks/useImportPdf.ts`
+
+```ts
+export const useImportPDF = () => {
+  const [isImporting, setIsImporting] = useState(false);
+  const [isProcessing, setIsProcessing] = useState(false);
+  const { setData } = useResume();
+  const { setValue } = usePdfSettings();
+
+  // Load PDF.js from CDN
+  const loadPDFJS = async () => {
+    if (window.pdfjsLib) return window.pdfjsLib;
+    
+    return new Promise((resolve, reject) => {
+      const script = document.createElement("script");
+      script.src = "https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.min.js";
+      script.onload = () => {
+        window.pdfjsLib.GlobalWorkerOptions.workerSrc = "...";
+        resolve(window.pdfjsLib);
+      };
+      document.head.appendChild(script);
+    });
+  };
+
+  // Extract text from PDF
+  const extractTextFromPDF = async (file: File) => {
+    const pdfjsLib = await loadPDFJS();
+    const arrayBuffer = await file.arrayBuffer();
+    const pdf = await pdfjsLib.getDocument({ data: arrayBuffer }).promise;
+    
+    let fullText = "";
+    for (let pageNum = 1; pageNum <= pdf.numPages; pageNum++) {
+      const page = await pdf.getPage(pageNum);
+      const textContent = await page.getTextContent();
+      fullText += textContent.items.map(item => item.str).join(" ");
+    }
+    
+    return { text: fullText.trim(), pageCount: pdf.numPages };
+  };
+
+  // Main import function
+  const importPDFData = async (file: File) => {
+    try {
+      validateFile(file); // Check type, size
+      setIsImporting(true);
+      
+      const { text } = await extractTextFromPDF(file);
+      setIsProcessing(true);
+      
+      const structuredData = await generateJSONFromText(text);
+      
+      setData(structuredData);
+      setValue("fontFamily", structuredData.pdfSettings.fontFamily);
+      setValue("fontSize", structuredData.pdfSettings.fontSize);
+      // ... other settings
+      
+      toast({ title: "PDF imported successfully!" });
+      return true;
+    } catch (error) {
+      toast({ title: "PDF import failed", description: error.message });
+      return false;
+    } finally {
+      setIsImporting(false);
+      setIsProcessing(false);
+    }
+  };
+
+  return { isImporting, isProcessing, importPDFData };
+};
+```
+
+### Image Import
+
+**File:** `src/hooks/useImportImage.ts`
+
+```ts
+export const useImportImage = () => {
+  const [isImporting, setIsImporting] = useState(false);
+  const { setData } = useResume();
+  const { setValue } = usePdfSettings();
+
+  const fileToBase64 = (file: File): Promise<string> => {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.readAsDataURL(file);
+      reader.onload = () => {
+        const base64String = (reader.result as string).split(",")[1];
+        resolve(base64String);
+      };
+      reader.onerror = reject;
+    });
+  };
+
+  const importImageData = async (file: File) => {
+    try {
+      validateFile(file);
+      setIsImporting(true);
+      
+      const base64Image = await fileToBase64(file);
+      const structuredData = await generateJSONFromImage(base64Image, file.type);
+      
+      setData(structuredData);
+      setValue("fontFamily", structuredData.pdfSettings.fontFamily);
+      // ... other settings
+      
+      toast({ title: "Image imported successfully!" });
+      return true;
+    } catch (error) {
+      toast({ title: "Image import failed", description: error.message });
+      return false;
+    } finally {
+      setIsImporting(false);
+    }
+  };
+
+  return { isImporting, importImageData };
+};
+```
+
+### JSON Import
+
+**File:** `src/hooks/useImportJson.ts`
+
+```ts
+export const useImportJSON = () => {
+  const [isImporting, setIsImporting] = useState(false);
+  const { setData } = useResume();
+  const { setValue } = usePdfSettings();
+
+  const importJSONData = async (validatedData: ValidatedData) => {
+    try {
+      setIsImporting(true);
+      
+      setData(validatedData);
+      setValue("fontFamily", validatedData.pdfSettings.fontFamily);
+      // ... other settings
+      
+      toast({ title: "File imported successfully" });
+      return true;
+    } catch (error) {
+      toast({ title: "Import failed" });
+      return false;
+    } finally {
+      setIsImporting(false);
+    }
+  };
+
+  return { isImporting, importJSONData };
+};
+```
+
+---
+
+## Skill 5: Rich Text Editor with AI Actions
+
+**File:** `src/components/core/RichTextEditor.tsx`
+
+### TipTap Extensions
+
+```ts
+const extensions = [
+  Document,
+  Text,
+  Bold,
+  Italic,
+  Paragraph,
+  ListItem,
+  BulletList,
+  OrderedList,
+  History,
+  Link.configure({
+    openOnClick: false,
+    autolink: true,
+    defaultProtocol: "https",
+  }),
+];
+```
+
+### AI Action Buttons
+
+```tsx
+const AiActionButtons = ({ content, handleChange, ... }) => {
+  const { editor } = useCurrentEditor();
+
+  const handleRewrite = async () => {
+    setIsRegenerating(true);
+    const regeneratedContent = await improveContent(content);
+    editor?.chain().focus().setContent(regeneratedContent).run();
+    handleChange(regeneratedContent);
+    setIsRegenerating(false);
+  };
+
+  const handleFixTypos = async () => {
+    setIsFixingTypos(true);
+    const fixedContent = await fixTypos(content);
+    editor?.chain().focus().setContent(fixedContent).run();
+    handleChange(fixedContent);
+    setIsFixingTypos(false);
+  };
+
+  const handleCustomize = async (prompt: string) => {
+    setIsCustomizing(true);
+    const customizedContent = await customizeContent(content, prompt);
+    editor?.chain().focus().setContent(customizedContent).run();
+    handleChange(customizedContent);
+    setIsCustomizing(false);
+  };
+
+  return (
+    <div>
+      <Button onClick={handleRewrite} disabled={isRegenerating}>
+        Improve Writing
+      </Button>
+      <Button onClick={handleFixTypos} disabled={isFixingTypos}>
+        Fix Typos
+      </Button>
+      <Select onValueChange={handleCustomize}>
+        <SelectTrigger>Customize</SelectTrigger>
+        <SelectContent>
+          <SelectItem value="shorter">Shorter</SelectItem>
+          <SelectItem value="longer">Longer</SelectItem>
+          <SelectItem value="formal">More Formal</SelectItem>
+          {/* ... */}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+};
+```
+
+---
+
+## Skill 6: Zustand Store Patterns
+
+### Creating a New Store
+
+```ts
+import { create } from "zustand";
+
+interface NewStoreType {
+  data: DataType;
+  isLoading: boolean;
+  setData: (data: DataType) => void;
+  setLoading: (isLoading: boolean) => void;
+}
+
+export const useNewStore = create<NewStoreType>((set) => ({
+  data: getLocalStorageData("newKey", defaultValue),
+  isLoading: false,
+  
+  setData: (data) => {
+    set({ data });
+    localStorage.setItem("newKey", JSON.stringify(data));
+  },
+  
+  setLoading: (isLoading) => set({ isLoading }),
+}));
+```
+
+### Updating Store with Partial Data
+
+```ts
+const { setData } = useResume();
+
+// Update single section
+setData({ experience: updatedExperience });
+
+// Update multiple sections
+setData({
+  experience: updatedExperience,
+  education: updatedEducation,
+});
+
+// Update nested object
+setData({
+  basics: {
+    ...resumeData.basics,
+    alignment: "center",
+  },
+});
+```
+
+### localStorage Migration Pattern
+
+```ts
+// Check for missing fields in old data
+if (localPdfSetting && localPdfSetting.skillsLayout === undefined) {
+  localPdfSetting.skillsLayout = "inline";
+  localStorage.setItem("pdfSetting", JSON.stringify(localPdfSetting));
+}
+```
+
+---
+
+## Skill 7: Form Validation with Zod
+
+### Defining Schemas
+
+```ts
+import { z } from "zod";
+
+const experienceSchema = z.object({
+  name: z.string().trim().min(1, { message: "Company is required" }),
+  position: z.string().trim().min(1, { message: "Position is required" }),
+  dateRange: z.string().trim().min(1, { message: "Date range is required" }),
+  location: z.string().trim(),
+  employmentType: z.string().min(1, { message: "Employment Type is required" }),
+  website: z.literal("").or(z.string().url()), // Allow empty or valid URL
+  summary: z.string().trim(),
+});
+```
+
+### Using with react-hook-form
+
+```tsx
+const form = useForm<z.infer<typeof schema>>({
+  resolver: zodResolver(schema),
+  defaultValues,
+});
+
+return (
+  <Form {...form}>
+    <form onSubmit={form.handleSubmit(onSubmit)}>
+      <FormField
+        control={form.control}
+        name="fieldName"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>Label</FormLabel>
+            <FormControl>
+              <Input {...field} />
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+    </form>
+  </Form>
+);
+```
+
+---
+
+## Skill 8: Responsive Design Patterns
+
+### Mobile Detection
+
+```tsx
+import { useWindowSize } from "@uidotdev/usehooks";
+
+const windowSize = useWindowSize();
+const isMobile = windowSize.width !== null && windowSize.width < 1024;
+```
+
+### Conditional Rendering
+
+```tsx
+{isMobile ? (
+  <MobileCvTabs />
+) : (
+  <div className="flex flex-col lg:flex-row">
+    <CvForm />
+    <Preview />
+  </div>
+)}
+```
+
+### Responsive Classes
+
+```tsx
+<div className="
+  w-full           // Mobile
+  sm:w-1/2         // Tablet
+  lg:w-1/3         // Desktop
+  xl:w-1/4         // Large desktop
+">
+  Content
+</div>
+
+<div className="
+  hidden           // Hidden on mobile
+  lg:flex          // Visible on desktop
+">
+  Desktop only
+</div>
+```
+
+---
+
+## Skill 9: Toast Notifications
+
+### Basic Usage
+
+```tsx
+import { toast } from "@/hooks/use-toast";
+
+// Success
+toast({
+  title: "Success",
+  description: "Operation completed",
+  variant: "success",
+});
+
+// Error
+toast({
+  title: "Error",
+  description: "Something went wrong",
+  variant: "destructive",
+});
+
+// Info
+toast({
+  title: "Processing",
+  description: "Please wait...",
+  variant: "default",
+});
+```
+
+### In Async Operations
+
+```tsx
+const handleAsyncOperation = async () => {
+  try {
+    toast({
+      title: "Processing...",
+      description: "Please wait",
+    });
+    
+    await asyncOperation();
+    
+    toast({
+      title: "Success!",
+      description: "Operation completed",
+      variant: "success",
+    });
+  } catch (error) {
+    toast({
+      title: "Error",
+      description: error instanceof Error ? error.message : "Unknown error",
+      variant: "destructive",
+    });
+  }
+};
+```
+
+---
+
+## Skill 10: Drag and Drop with dnd-kit
+
+### Section Reordering
+
+**File:** `src/components/core/DndSections.tsx`
+
+```tsx
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+
+export default function DndSections() {
+  const { sectionOrder, setSectionOrder } = useResume();
+
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    })
+  );
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+
+    if (over && active.id !== over.id) {
+      const oldIndex = sectionOrder.indexOf(active.id as SectionName);
+      const newIndex = sectionOrder.indexOf(over.id as SectionName);
+      const newOrder = arrayMove(sectionOrder, oldIndex, newIndex);
+      setSectionOrder(newOrder);
+    }
+  };
+
+  return (
+    <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+      <SortableContext items={sectionOrder} strategy={verticalListSortingStrategy}>
+        {sectionOrder.map((sectionId) => (
+          <SortableItem key={sectionId} id={sectionId}>
+            {sectionTitles[sectionId]}
+          </SortableItem>
+        ))}
+      </SortableContext>
+    </DndContext>
+  );
+}
+```
+
+---
+
+## Quick Reference: Common Imports
+
+```tsx
+// Store
+import { useResume, usePdfSettings, useAnalysis } from "@/store/useResume";
+
+// Hooks
+import { useDialog } from "@/hooks/useDialog";
+import { toast } from "@/hooks/use-toast";
+
+// Utils
+import { cn } from "@/lib/utils";
+
+// UI Components
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+
+// Icons
+import { IconName } from "lucide-react";
+
+// Types
+import { Experience, Project, Education } from "@/types/types";
+
+// Constants
+import { PDF_SETTINGS, ATS_FRIENDLY_FONTS } from "@/lib/constants";
+
+// AI Service
+import { improveContent, fixTypos, aiReview } from "@/services/groqService";
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,565 @@
+# CV Master - Agent Guide
+
+## Project Overview
+
+CV Master is an AI-powered resume builder that helps users create professional resumes with intelligent suggestions, PDF export, and ATS-friendly formatting.
+
+### Tech Stack
+
+**Frontend (Root `/`):**
+- React 18 + TypeScript + Vite
+- Zustand (state management)
+- Shadcn UI + Radix UI (component library)
+- Tailwind CSS (styling)
+- Groq SDK (AI integration - client-side)
+- TipTap (rich text editor)
+- dnd-kit (drag and drop)
+- react-hook-form + Zod (forms and validation)
+- react-router (routing)
+- react-zoom-pan-pinch (preview zoom)
+
+**Backend (`/backend/`):**
+- Node.js + Express (plain JavaScript, not TypeScript)
+- Puppeteer + @sparticuz/chromium (PDF generation)
+- Cloudinary (file storage for PDFs and profile photos)
+- express-rate-limit (rate limiting)
+
+**Deployment:**
+- Vercel (both frontend and backend)
+
+## Architecture Summary
+
+### Project Structure
+
+This is **not** a monorepo. It's two separate packages:
+- `/` - Frontend (React + Vite)
+- `/backend/` - Backend (Express API)
+
+No monorepo tooling (no Turborepo, Nx, or workspaces).
+
+### State Management
+
+Three Zustand stores in `src/store/useResume.ts`:
+
+1. **`useResume`** - Main resume data
+   - `resumeData`: All CV sections (basics, summary, experience, etc.)
+   - `sectionOrder`: Array defining section display order
+   - `setData()`: Updates resume data and syncs to localStorage
+   - `setSectionOrder()`: Updates section order and syncs to localStorage
+
+2. **`usePdfSettings`** - PDF/rendering settings
+   - `pdfSettings`: Font, spacing, margins, scale, etc.
+   - `setValue()`: Updates individual settings and syncs to localStorage
+
+3. **`useAnalysis`** - AI review results
+   - `currentAnalysis`: Last AI review result
+   - `isAnalyzing`: Loading state
+   - `setAnalysis()`, `clearAnalysis()`, `setError()`
+
+**localStorage Keys:**
+- `resumeData` - Resume content
+- `pdfSetting` - PDF settings (note: singular "Setting")
+- `sectionOrder` - Section display order
+- `currentAnalysis` - Last AI review
+
+### Dialog System
+
+Context/Provider pattern:
+- `DialogContext` (`src/contexts/DialogContext.tsx`) - Context definition
+- `DialogProvider` (`src/providers/DialogProvider.tsx`) - Provider with state management
+- `useDialog` hook (`src/hooks/useDialog.tsx`) - Consumer hook
+
+Dialogs are rendered conditionally in `DialogProvider` based on `openDialogId`.
+
+### AI Integration
+
+All AI calls happen **client-side** via Groq SDK in `src/services/groqService.ts`:
+
+- `improveContent()` - Rewrite/improve text (model: `llama-3.1-8b-instant`)
+- `fixTypos()` - Fix spelling/grammar (model: `llama-3.1-8b-instant`)
+- `customizeContent()` - Customize tone/length (model: `llama-3.1-8b-instant`)
+- `generateJSONFromText()` - Parse PDF text to JSON (model: `openai/gpt-oss-120b`)
+- `generateJSONFromImage()` - Parse image to JSON (model: `meta-llama/llama-4-scout-17b-16e-instruct`)
+- `aiReview()` - Comprehensive CV review (model: `openai/gpt-oss-120b`)
+
+### Data Flow
+
+**Import PDF:**
+1. User uploads PDF → `useImportPDF` hook
+2. PDF.js extracts text (client-side)
+3. Text sent to Groq → `generateJSONFromText()`
+4. AI returns structured JSON
+5. Store updated via `setData()` and `setValue()`
+
+**Import Image:**
+1. User uploads image → `useImportImage` hook
+2. Image converted to base64
+3. Base64 sent to Groq Vision API → `generateJSONFromImage()`
+4. AI returns structured JSON
+5. Store updated
+
+**Export PDF:**
+1. User clicks download → `DownloadCV` component
+2. `<Page mode="print" />` rendered to hidden div
+3. HTML extracted and sent to backend `/pdf` endpoint
+4. Backend uses Puppeteer to generate PDF
+5. PDF uploaded to Cloudinary
+6. Download URL returned to client
+
+**AI Review:**
+1. User enters job title/description → `ReviewCvDialog`
+2. Resume JSON + job info sent to Groq → `aiReview()`
+3. AI returns analysis with scores and recommendations
+4. Stored in `useAnalysis` store
+5. User navigated to `/review` page to view results
+
+## Key Files Map
+
+### Frontend
+
+**Core:**
+- `src/App.tsx` - Main app component, routing, layout
+- `src/main.tsx` - Entry point, React Router setup
+- `src/store/useResume.ts` - All Zustand stores (resume, PDF settings, analysis)
+- `src/services/groqService.ts` - All AI/Groq API calls
+- `src/types/types.ts` - TypeScript interfaces for all data structures
+
+**Libraries:**
+- `src/lib/schema.ts` - Zod schemas for validation
+- `src/lib/constants.ts` - PDF settings, fonts, icons
+- `src/lib/utils.ts` - `cn()` utility for class names
+- `src/lib/googleFonts.ts` - Google Fonts API integration
+
+**Layout:**
+- `src/components/layout/CvForm.tsx` - Left panel with form sections
+- `src/components/layout/Preview.tsx` - Right panel with zoom/pan preview
+- `src/components/layout/Header.tsx` - Top navigation bar
+
+**Sections (Form):**
+- `src/components/sections/basics.tsx` - Personal info form
+- `src/components/sections/summary.tsx` - Summary form
+- `src/components/sections/shared/SectionBase.tsx` - Reusable section wrapper
+- `src/components/sections/dialogs/*.tsx` - Dialog forms for each section
+
+**Preview:**
+- `src/components/preview/index.tsx` - Main preview renderer (`<Page />`)
+- `src/components/preview/basics.tsx` - Personal info preview
+- `src/components/preview/*.tsx` - Preview for each section
+
+**Core Components:**
+- `src/components/core/DownloadCV.tsx` - PDF/JSON export
+- `src/components/core/ImportCV.tsx` - Import dialog trigger
+- `src/components/core/RichTextEditor.tsx` - TipTap editor with AI actions
+- `src/components/core/Controls.tsx` - Zoom/pan controls
+- `src/components/core/ControlsSheet.tsx` - Settings sheet (fonts, spacing, etc.)
+- `src/components/core/DndSections.tsx` - Drag-and-drop section reordering
+- `src/components/core/ReviewBtn.tsx` - AI review trigger
+- `src/components/core/ReviewResult.tsx` - AI review results display
+
+**Hooks:**
+- `src/hooks/useImportPdf.ts` - PDF import logic
+- `src/hooks/useImportImage.ts` - Image import logic
+- `src/hooks/useImportJson.ts` - JSON import logic
+- `src/hooks/useValidateJson.ts` - JSON validation
+- `src/hooks/useDialog.tsx` - Dialog context consumer
+- `src/hooks/use-toast.ts` - Toast notifications
+
+**Providers:**
+- `src/providers/ThemeProvider.tsx` - Dark/light theme
+- `src/providers/DialogProvider.tsx` - Dialog state management
+
+**UI:**
+- `src/components/ui/*.tsx` - Shadcn UI components (auto-generated, don't edit directly)
+
+### Backend
+
+- `backend/index.js` - Express server, all routes
+- `backend/package.json` - Backend dependencies
+- `backend/vercel.json` - Vercel deployment config
+
+**Routes:**
+- `GET /` - Health check
+- `POST /pdf` - Generate PDF from HTML (Puppeteer + Cloudinary)
+- `POST /upload-photo` - Upload profile photo (Cloudinary, rate-limited)
+
+## Development Guidelines
+
+### Code Style
+
+- **Path aliases**: Use `@/` for `src/` imports (configured in `tsconfig.json` and `vite.config.ts`)
+- **Class names**: Use `cn()` utility from `@/lib/utils` to merge Tailwind classes
+- **Component exports**: Named exports for components (e.g., `export const Header`)
+- **Icons**: Use Lucide React icons, custom icons in `src/components/core/icons/`
+- **IDs**: Use `crypto.randomUUID()` for generating unique IDs
+
+### Component Patterns
+
+**Section Dialogs:**
+```tsx
+// 1. Define Zod schema
+const schema = z.object({ ... });
+
+// 2. Use react-hook-form with zodResolver
+const form = useForm<z.infer<typeof schema>>({
+  resolver: zodResolver(schema),
+  defaultValues,
+});
+
+// 3. Get dialog state from context
+const { isOpen, closeDialog, index } = useDialog();
+
+// 4. Get store data and setter
+const { setData, resumeData: { sectionName } } = useResume();
+
+// 5. Handle submit
+const onSubmit = (data) => {
+  const itemWithId = isEditMode
+    ? { ...data, id: existingItem.id }
+    : { ...data, id: crypto.randomUUID() };
+  
+  const updated = isEditMode
+    ? items.map((item, i) => i === index ? itemWithId : item)
+    : [...items, itemWithId];
+  
+  setData({ sectionName: updated });
+  closeDialog();
+  form.reset();
+};
+```
+
+**Preview Components:**
+```tsx
+// Access store data
+const { resumeData: { sectionName } } = useResume();
+const { pdfSettings: { ... } } = usePdfSettings();
+
+// Render with Tailwind classes
+// Use cn() for conditional classes
+```
+
+**Zustand Store Updates:**
+```tsx
+// Always use the provided actions, never mutate directly
+const { setData } = useResume();
+setData({ sectionName: newData }); // Correct
+
+// Never do this:
+// resumeData.sectionName = newData; // Wrong!
+```
+
+### API Route Patterns (Backend)
+
+```js
+// Express route with error handling
+app.post('/endpoint', async (req, res) => {
+  const { data } = req.body;
+  
+  if (!data) {
+    return res.status(400).json({ message: "Data is required" });
+  }
+  
+  try {
+    // Process data
+    const result = await processData(data);
+    res.json({ success: true, result });
+  } catch (error) {
+    console.error("Error:", error);
+    res.status(500).json({ message: "Internal server error" });
+  }
+});
+```
+
+### Toast Notifications
+
+```tsx
+import { toast } from "@/hooks/use-toast";
+
+toast({
+  title: "Success",
+  description: "Operation completed",
+  variant: "default", // or "destructive" or "success"
+});
+```
+
+## Common Tasks
+
+### Adding a New Resume Section
+
+1. **Define types** in `src/types/types.ts`:
+   ```ts
+   export interface NewSection {
+     id: string;
+     name: string;
+     // ... other fields
+   }
+   ```
+
+2. **Add to `ResumeType`** interface in `types.ts`
+
+3. **Create Zod schema** in `src/lib/schema.ts`:
+   ```ts
+   const newSectionSchema = z.object({ ... });
+   ```
+
+4. **Add to store defaults** in `src/store/useResume.ts`:
+   ```ts
+   const DEFAULT_RESUME_DATA = {
+     // ...
+     newSection: [],
+   };
+   ```
+
+5. **Add to `sectionTitles`** in store defaults
+
+6. **Create dialog component** in `src/components/sections/dialogs/newSection.tsx`:
+   - Use react-hook-form + Zod
+   - Follow existing dialog patterns
+
+7. **Register dialog** in `src/providers/DialogProvider.tsx`:
+   ```tsx
+   {isOpen("newSection") && <NewSectionDialog />}
+   ```
+
+8. **Create preview component** in `src/components/preview/newSection.tsx`
+
+9. **Add to preview renderer** in `src/components/preview/index.tsx`:
+   ```tsx
+   case "newSection":
+     return <NewSectionPreview key={sectionId} />;
+   ```
+
+10. **Add to form** in `src/components/layout/CvForm.tsx`:
+    ```tsx
+    <SectionBase id="newSection" name="New Section" itemsCount={...} />
+    ```
+
+11. **Add to section order** in store defaults
+
+12. **Add icon** in `src/components/sections/shared/SectionIcon.tsx`
+
+13. **Add to sidebar** in `src/components/core/SidebarNavigation.tsx`
+
+### Adding a New AI Prompt
+
+1. **Add function** in `src/services/groqService.ts`:
+   ```ts
+   export async function newAIFunction(input: string) {
+     try {
+       const response = await groq.chat.completions.create({
+         messages: [
+           { role: "system", content: "..." },
+           { role: "user", content: input },
+         ],
+         model: "llama-3.1-8b-instant", // or other model
+         temperature: 0.1,
+         max_tokens: 1024,
+         stream: false,
+       });
+       
+       return response.choices[0]?.message?.content?.trim() || "No response";
+     } catch (error) {
+       console.error(error);
+       return "No response";
+     }
+   }
+   ```
+
+2. **Use in component**:
+   ```tsx
+   const result = await newAIFunction(userInput);
+   ```
+
+### Adding a New API Route (Backend)
+
+1. **Add route** in `backend/index.js`:
+   ```js
+   app.post('/new-endpoint', async (req, res) => {
+     // Implementation
+   });
+   ```
+
+2. **Add rate limiting** if needed:
+   ```js
+   const limiter = rateLimit({
+     windowMs: 15 * 60 * 1000,
+     max: 10,
+   });
+   
+   app.post('/new-endpoint', limiter, async (req, res) => { ... });
+   ```
+
+3. **Update CORS** if new origins needed (currently allows `*`)
+
+### Adding a New Zustand Store Slice
+
+1. **Add to store** in `src/store/useResume.ts`:
+   ```ts
+   export const useNewStore = create<NewStoreType>((set) => ({
+     data: defaultValue,
+     setData: (data) => {
+       set({ data });
+       localStorage.setItem("newKey", JSON.stringify(data));
+     },
+   }));
+   ```
+
+2. **Initialize from localStorage** if needed:
+   ```ts
+   const localData = getLocalStorageData("newKey");
+   ```
+
+## Agent Rules
+
+### Always Do
+
+- Use Shadcn UI primitives from `@/components/ui/` for new UI elements
+- Use `cn()` utility for merging Tailwind classes
+- Use `crypto.randomUUID()` for generating unique IDs
+- Update localStorage when modifying Zustand stores (use provided actions)
+- Use react-hook-form + Zod for all form validation
+- Use `toast()` for user notifications
+- Follow existing component patterns (check similar components first)
+- Use path aliases (`@/`) for imports
+- Test responsive behavior on mobile (< 1024px) and desktop
+- Run `npm run lint` after changes
+- Run `npm run build` to verify TypeScript compilation
+
+### Never Do
+
+- Don't directly mutate Zustand store state (always use actions)
+- Don't edit files in `src/components/ui/` directly (they're auto-generated by Shadcn)
+- Don't use inline styles when Tailwind classes exist
+- Don't add comments unless explicitly requested
+- Don't use `any` type (use proper TypeScript types)
+- Don't break existing localStorage key names (migration logic exists)
+- Don't use `console.log` in production code (use proper error handling)
+- Don't hardcode API URLs (use environment variables)
+- Don't forget to handle loading/error states for async operations
+- Don't skip form validation (always use Zod schemas)
+
+### Check Before Making Changes
+
+- Verify the component doesn't already exist in `src/components/`
+- Check if a similar pattern exists elsewhere in the codebase
+- Ensure TypeScript types are updated if data structures change
+- Verify Zod schemas match TypeScript interfaces
+- Check if localStorage migration is needed for existing users
+- Ensure mobile responsive behavior is maintained
+- Verify dark mode compatibility (use CSS variables from `index.css`)
+
+## Environment Variables
+
+### Frontend (`.env` in root)
+
+```bash
+VITE_GROQ_API_KEY="your_groq_api_key"
+# Required for AI features. Get from https://console.groq.com
+
+VITE_BACKEND_URL="http://localhost:5000"
+# Required for PDF export. Backend URL (local or Vercel)
+
+VITE_GOOGLE_FONTS_API_KEY="your_google_fonts_api_key"
+# Optional. Used in constants.ts but not documented in .env.example
+# Get from https://developers.google.com/fonts/docs/developer_api
+```
+
+### Backend (`.env` in `/backend/`)
+
+```bash
+CLOUD_NAME="your_cloudinary_cloud_name"
+API_KEY="your_cloudinary_api_key"
+API_SECRET="your_cloudinary_api_secret"
+# Required for PDF and photo storage. Get from https://cloudinary.com
+
+CLIENT_URL="http://localhost:3000"
+# Optional. Currently CORS allows all origins (*)
+
+NODE_ENV="development"
+# Set to "production" for Vercel deployment (uses puppeteer-core)
+
+PORT=5000
+# Optional. Defaults to 5000
+```
+
+## Testing and Build
+
+### Frontend
+
+```bash
+# Install dependencies
+npm install
+
+# Development server (http://localhost:3000)
+npm run dev
+
+# Build for production
+npm run build
+
+# Preview production build
+npm run preview
+
+# Lint code
+npm run lint
+```
+
+**No tests currently exist** for the frontend.
+
+### Backend
+
+```bash
+cd backend
+
+# Install dependencies
+npm install
+
+# Start development server (http://localhost:5000)
+node index.js
+
+# Or with nodemon for auto-reload
+npx nodemon index.js
+```
+
+**No tests currently exist** for the backend.
+
+### Deployment
+
+Both frontend and backend deploy to Vercel:
+- Frontend: Root directory, Vite build
+- Backend: `/backend/` directory, `@vercel/node` runtime
+
+See `backend/vercel.json` for backend routing config.
+
+## Additional Notes
+
+### Mobile Responsive Behavior
+
+- `< 1024px`: Mobile layout with tabs (`MobileCvTabs`)
+- `>= 1024px`: Desktop layout with side-by-side form and preview
+- Sidebar navigation hidden on mobile, visible on desktop
+- Header menu becomes dropdown on mobile
+
+### Theme System
+
+- Uses `ThemeProvider` with localStorage persistence
+- CSS variables defined in `src/index.css` for light/dark modes
+- Access via `useTheme()` hook from `@/providers/ThemeProvider`
+
+### Font System
+
+- Default font: "Work Sans"
+- ATS-Friendly fonts: Predefined list in `constants.ts`
+- Other fonts: Fetched from Google Fonts API
+- Font loading: Dynamic `<link>` tag injection via `loadGoogleFont()`
+
+### PDF Generation
+
+- Client renders `<Page mode="print" />` to hidden div
+- HTML extracted and sent to backend
+- Backend uses Puppeteer (local) or puppeteer-core + @sparticuz/chromium (production)
+- PDF uploaded to Cloudinary, URL returned
+- Client triggers download from Cloudinary URL
+
+### Rate Limiting
+
+- Photo upload: 10 requests per 15 minutes per IP
+- AI features: Limited by Groq API quotas (handled client-side)

--- a/src/components/core/DownloadCV.tsx
+++ b/src/components/core/DownloadCV.tsx
@@ -3,23 +3,13 @@ import { flushSync } from "react-dom";
 import { Button } from "../ui/button";
 import { Download, LoaderCircle } from "lucide-react";
 import { Page } from "../preview";
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import { toast } from "../../hooks/use-toast";
 import { Basics } from "../../types/types";
 import { usePdfSettings, useResume } from "../../store/useResume";
 import { cn } from "../../lib/utils";
 import { DownloadOptionsDialog } from "./dialogs/DownloadOptionsDialog";
 import { buildFontCssUrl } from "../../lib/googleFonts";
-
-const div = document.createElement("div");
-const root = createRoot(div);
-flushSync(() => {
-  root.render(
-    <>
-      <Page mode="print" />
-    </>
-  );
-});
 
 interface DownloadCVProps {
   className?: string;
@@ -29,7 +19,7 @@ interface DownloadCVProps {
 export const DownloadCV: React.FC<DownloadCVProps> = ({ className, type }) => {
   const [isLoading, setIsLoading] = useState(false);
   const [isDialogOpen, setIsDialogOpen] = useState(false);
-  const { resumeData } = useResume();
+  const { resumeData, hiddenItemIds } = useResume();
   const {
     pdfSettings: {
       fontFamily,
@@ -43,6 +33,21 @@ export const DownloadCV: React.FC<DownloadCVProps> = ({ className, type }) => {
     },
   } = usePdfSettings();
   const { basics } = resumeData;
+
+  // Render the print version of the page into a detached div and return the HTML.
+  // Re-rendered on every call so the latest state (e.g. hiddenInPdf) is reflected.
+  const renderPrintHtml = useCallback((): string => {
+    const div = document.createElement("div");
+    const root = createRoot(div);
+    flushSync(() => {
+      root.render(
+        <>
+          <Page mode="print" />
+        </>
+      );
+    });
+    return div.innerHTML;
+  }, []);
 
   // render CVPreview component to HTML
   const getHtmlContent = () => {
@@ -77,7 +82,7 @@ export const DownloadCV: React.FC<DownloadCVProps> = ({ className, type }) => {
 			</style>
 			<body>
 				<!-- Add other dynamic sections here with Tailwind classes -->
-				${div.innerHTML}
+				${renderPrintHtml()}
 			</body>
 		</html>`;
   };
@@ -174,6 +179,7 @@ export const DownloadCV: React.FC<DownloadCVProps> = ({ className, type }) => {
     const json = JSON.stringify(
       {
         ...resumeData,
+        hiddenItemIds,
         pdfSettings: {
           fontFamily,
           fontSize,

--- a/src/components/preview/awards.tsx
+++ b/src/components/preview/awards.tsx
@@ -4,11 +4,16 @@ import { Award } from "../../types/types";
 export const AwardsPreview: React.FC = () => {
   const {
     resumeData: { awards, sectionTitles },
+    hiddenItemIds,
   } = useResume();
 
   const {
     pdfSettings: { lineHeight, fontSize },
   } = usePdfSettings();
+
+  const visibleAwards = awards.filter(
+    (award) => !hiddenItemIds.includes(award.id)
+  );
 
   // remove bullets from the description
   const removeBulletPoints = (summary: string) => {
@@ -16,13 +21,13 @@ export const AwardsPreview: React.FC = () => {
   };
 
   // process education data to display in the component
-  const processedEducation = awards.map((award: Award) => ({
+  const processedEducation = visibleAwards.map((award: Award) => ({
     ...award,
     summary: removeBulletPoints(award.summary),
   }));
 
   // IF there are no awards, return null
-  if (!awards || awards.length === 0) {
+  if (!visibleAwards || visibleAwards.length === 0) {
     return null;
   }
 

--- a/src/components/preview/certifications.tsx
+++ b/src/components/preview/certifications.tsx
@@ -4,11 +4,16 @@ import { Certification } from "../../types/types";
 export const CertificationsPreview: React.FC = () => {
   const {
     resumeData: { certifications, sectionTitles },
+    hiddenItemIds,
   } = useResume();
 
   const {
     pdfSettings: { lineHeight, fontSize },
   } = usePdfSettings();
+
+  const visibleCertifications = certifications.filter(
+    (cert) => !hiddenItemIds.includes(cert.id)
+  );
 
   // remove bullets from the description
   const removeBulletPoints = (summary: string) => {
@@ -16,13 +21,13 @@ export const CertificationsPreview: React.FC = () => {
   };
 
   // process education data to display in the component
-  const processedEducation = certifications.map((cert: Certification) => ({
+  const processedEducation = visibleCertifications.map((cert: Certification) => ({
     ...cert,
     summary: removeBulletPoints(cert.summary),
   }));
 
   // IF there are no certifications, return null
-  if (!certifications || certifications.length === 0) {
+  if (!visibleCertifications || visibleCertifications.length === 0) {
     return null;
   }
 

--- a/src/components/preview/education.tsx
+++ b/src/components/preview/education.tsx
@@ -4,11 +4,16 @@ import { Education } from "../../types/types";
 export const EducationPreview: React.FC = () => {
   const {
     resumeData: { education, sectionTitles },
+    hiddenItemIds,
   } = useResume();
 
   const {
     pdfSettings: { lineHeight, fontSize },
   } = usePdfSettings();
+
+  const visibleEducation = education.filter(
+    (edu) => !hiddenItemIds.includes(edu.id)
+  );
 
   // remove bullets from the description
   const removeBulletPoints = (summary: string) => {
@@ -16,13 +21,13 @@ export const EducationPreview: React.FC = () => {
   };
 
   // process education data to display in the component
-  const processedEducation = education.map((edu: Education) => ({
+  const processedEducation = visibleEducation.map((edu: Education) => ({
     ...edu,
     summary: removeBulletPoints(edu.summary),
   }));
 
   // IF there are no education, return null
-  if (!education || education.length === 0) {
+  if (!visibleEducation || visibleEducation.length === 0) {
     return null;
   }
 

--- a/src/components/preview/experience.tsx
+++ b/src/components/preview/experience.tsx
@@ -4,11 +4,17 @@ import { Experience } from "../../types/types";
 export const ExperiencePreview: React.FC = () => {
   const {
     resumeData: { experience, sectionTitles },
+    hiddenItemIds,
   } = useResume();
 
   const {
     pdfSettings: { lineHeight, fontSize },
   } = usePdfSettings();
+
+  // filter out hidden items
+  const visibleExperience = experience.filter(
+    (exp) => !hiddenItemIds.includes(exp.id)
+  );
 
   // remove bullets from the description
   const removeBulletPoints = (summary: string) => {
@@ -16,12 +22,12 @@ export const ExperiencePreview: React.FC = () => {
   };
 
   // process experience data to display in the component
-  const processedExperience = experience.map((exp: Experience) => ({
+  const processedExperience = visibleExperience.map((exp: Experience) => ({
     ...exp,
     summary: removeBulletPoints(exp.summary),
   }));
 
-  if (!experience || experience.length === 0) {
+  if (!visibleExperience || visibleExperience.length === 0) {
     return null;
   }
 
@@ -33,7 +39,7 @@ export const ExperiencePreview: React.FC = () => {
       >
         {sectionTitles.experience}
       </h3>
-      {experience &&
+      {visibleExperience &&
         processedExperience.map((exp: Experience) => (
           <div key={exp.id}>
             <div className="flex items-center justify-between">

--- a/src/components/preview/languages.tsx
+++ b/src/components/preview/languages.tsx
@@ -4,14 +4,19 @@ import { Language } from "../../types/types";
 export const LanguagesPreview: React.FC = () => {
   const {
     resumeData: { languages, sectionTitles },
+    hiddenItemIds,
   } = useResume();
 
   const {
     pdfSettings: { fontSize, lineHeight },
   } = usePdfSettings();
 
+  const visibleLanguages = languages.filter(
+    (lang) => !hiddenItemIds.includes(lang.id)
+  );
+
   // IF there are no languages, return null
-  if (!languages || languages.length === 0) {
+  if (!visibleLanguages || visibleLanguages.length === 0) {
     return null;
   }
 
@@ -24,7 +29,7 @@ export const LanguagesPreview: React.FC = () => {
         {sectionTitles.languages}
       </h3>
       <div style={{ lineHeight: `${lineHeight * 0.25}rem` }}>
-        {languages.map((lang: Language) => (
+        {visibleLanguages.map((lang: Language) => (
           <div key={lang.id}>
             <span className="font-bold">{lang.name}</span>: {lang.level}
           </div>

--- a/src/components/preview/projects.tsx
+++ b/src/components/preview/projects.tsx
@@ -4,23 +4,28 @@ import { Project } from "../../types/types";
 export const ProjectsPreview: React.FC = () => {
   const {
     resumeData: { projects, sectionTitles },
+    hiddenItemIds,
   } = useResume();
 
   const {
     pdfSettings: { lineHeight, fontSize },
   } = usePdfSettings();
 
+  const visibleProjects = projects.filter(
+    (project) => !hiddenItemIds.includes(project.id)
+  );
+
   // remove bullet points from the summary
   const removeBulletPoints = (summary: string) => {
     return summary.replace(/• /g, "");
   };
   //processed data
-  const processedExperience = projects.map((project: Project) => ({
+  const processedExperience = visibleProjects.map((project: Project) => ({
     ...project,
     summary: removeBulletPoints(project.summary),
   }));
   // IF there are no projects, return null
-  if (!projects || projects.length === 0) {
+  if (!visibleProjects || visibleProjects.length === 0) {
     return null;
   }
   return (

--- a/src/components/preview/skills.tsx
+++ b/src/components/preview/skills.tsx
@@ -5,23 +5,28 @@ import { Skill } from "../../types/types";
 export const SkillsPreview: React.FC = () => {
   const {
     resumeData: { skills, sectionTitles },
+    hiddenItemIds,
   } = useResume();
 
   const {
     pdfSettings: { fontSize, lineHeight, skillsLayout },
   } = usePdfSettings();
 
+  const visibleSkills = skills.filter(
+    (skill) => !hiddenItemIds.includes(skill.id)
+  );
+
   // IF there are no skills, return null
-  if (!skills || skills.length === 0) {
+  if (!visibleSkills || visibleSkills.length === 0) {
     return null;
   }
 
   const isGridLayout = skillsLayout !== "inline";
   const gridTemplateStyles =
     skillsLayout === "grid-col"
-      ? { gridTemplateColumns: `repeat(${skills.length}, minmax(0, 1fr))` }
+      ? { gridTemplateColumns: `repeat(${visibleSkills.length}, minmax(0, 1fr))` }
       : skillsLayout === "grid-row"
-      ? { gridTemplateRows: `repeat(${skills.length}, minmax(0, 1fr))` }
+      ? { gridTemplateRows: `repeat(${visibleSkills.length}, minmax(0, 1fr))` }
       : {};
 
   return (
@@ -44,7 +49,7 @@ export const SkillsPreview: React.FC = () => {
       >
         {skillsLayout === "inline" ? (
           <>
-            {skills.map((skill: Skill) => (
+            {visibleSkills.map((skill: Skill) => (
               <div key={skill.id}>
                 {skill.name && (
                   <span className="font-bold">{skill.name}: </span>
@@ -60,7 +65,7 @@ export const SkillsPreview: React.FC = () => {
           </>
         ) : (
           <>
-            {skills.map((skill: Skill) => (
+            {visibleSkills.map((skill: Skill) => (
               <div key={skill.id}>
                 {skill.name && (
                   <span className="font-bold">{skill.name}: </span>

--- a/src/components/preview/volunteering.tsx
+++ b/src/components/preview/volunteering.tsx
@@ -4,11 +4,16 @@ import { Volunteering } from "../../types/types";
 export const VolunteeringPreview: React.FC = () => {
   const {
     resumeData: { volunteering, sectionTitles },
+    hiddenItemIds,
   } = useResume();
 
   const {
     pdfSettings: { lineHeight, fontSize },
   } = usePdfSettings();
+
+  const visibleVolunteering = volunteering.filter(
+    (vol) => !hiddenItemIds.includes(vol.id)
+  );
 
   // remove bullets from the description
   const removeBulletPoints = (summary: string) => {
@@ -16,13 +21,13 @@ export const VolunteeringPreview: React.FC = () => {
   };
 
   // process education data to display in the component
-  const processedEducation = volunteering.map((vol: Volunteering) => ({
+  const processedEducation = visibleVolunteering.map((vol: Volunteering) => ({
     ...vol,
     summary: removeBulletPoints(vol.summary),
   }));
 
   // IF there are no volunteering, return null
-  if (!volunteering || volunteering.length === 0) {
+  if (!visibleVolunteering || visibleVolunteering.length === 0) {
     return null;
   }
 

--- a/src/components/sections/shared/SectionBase.tsx
+++ b/src/components/sections/shared/SectionBase.tsx
@@ -1,4 +1,12 @@
-import { Copy, Pencil, Plus, Trash } from "lucide-react";
+import {
+  Copy,
+  Eye,
+  EyeOff,
+  MoreVertical,
+  Pencil,
+  Plus,
+  Trash,
+} from "lucide-react";
 import { Button } from "../../ui/button";
 import { useDialog } from "../../../hooks/useDialog";
 import { useResume } from "../../../store/useResume";
@@ -8,10 +16,17 @@ import { useState, useMemo, useRef, useEffect } from "react";
 import { DeleteConfirmation } from "../../core/dialogs/DeleteConfirmation";
 import { cn } from "../../../lib/utils";
 import { Input } from "../../ui/input";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "../../ui/dropdown-menu";
 
 export const SectionBase: React.FC<Section> = ({ name, itemsCount, id }) => {
   const { openDialog, updateDialog } = useDialog();
-  const { resumeData, setData } = useResume();
+  const { resumeData, setData, hiddenItemIds, toggleHiddenItem } = useResume();
   const [deleteDialog, setDeleteDialog] = useState<{
     isOpen: boolean;
     index: number | null;
@@ -22,7 +37,7 @@ export const SectionBase: React.FC<Section> = ({ name, itemsCount, id }) => {
   const [itemToDelete, setItemToDelete] = useState<number | null>(null);
   const [isEditingTitle, setIsEditingTitle] = useState(false);
   const [sectionTitle, setSectionTitle] = useState(
-    resumeData.sectionTitles[id] || name
+    resumeData.sectionTitles[id] || name,
   );
 
   // Track rendered items to prevent re-animation
@@ -133,17 +148,19 @@ export const SectionBase: React.FC<Section> = ({ name, itemsCount, id }) => {
           sectionData.map((item: SectionItem, index: number) => {
             // Check if this item should animate in (new item)
             const shouldAnimateIn = !renderedItems.current.has(
-              item.id as string
+              item.id as string,
             );
+            const isItemHidden = hiddenItemIds.includes(item.id as string);
 
             return (
               <li
                 key={item.id as string}
                 className={cn(
-                  "border border-border p-4 duration-300 group rounded-sm",
+                  "border border-border p-4 duration-300 rounded-sm transition-opacity",
                   shouldAnimateIn && "animate-in slide-in-from-top fade-in",
                   itemToDelete === index &&
-                    "animate-out slide-out-to-left fade-out"
+                    "animate-out slide-out-to-left fade-out",
+                  isItemHidden && "opacity-50",
                 )}
               >
                 <div className="flex items-center justify-between">
@@ -174,44 +191,53 @@ export const SectionBase: React.FC<Section> = ({ name, itemsCount, id }) => {
                       ) : null
                     }
                   </div>
-                  <div className="lg:opacity-0 group-hover:opacity-100 transition-opacity duration-300 flex">
-                    <Button
-                      aria-label={`Edit ${item.name}`}
-                      title="Edit"
-                      variant="ghost"
-                      size="icon"
-                      onClick={() => updateDialog(id, index)}
-                    >
-                      <Pencil />
-                    </Button>
-                    <Button
-                      aria-label={`Duplicate ${item.name}`}
-                      title="Duplicate"
-                      variant="ghost"
-                      size="icon"
-                      onClick={() => {
-                        // duplicate the item
-                        const newItem = {
-                          ...item,
-                          id: crypto.randomUUID(),
-                        };
-                        setData({ [id]: [...sectionData, newItem] });
-                      }}
-                    >
-                      <Copy />
-                    </Button>
-                    <Button
-                      aria-label={`Delete ${item.name}`}
-                      title="Delete"
-                      variant="ghost"
-                      size="icon"
-                      onClick={() => {
-                        setDeleteDialog({ isOpen: true, index: index });
-                      }}
-                    >
-                      <Trash />
-                    </Button>
-                  </div>
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button
+                        aria-label={`Actions for ${item.name}`}
+                        title="Actions"
+                        variant="ghost"
+                        size="icon"
+                        className="transition-opacity duration-300 rounded-full"
+                      >
+                        <MoreVertical />
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end">
+                      <DropdownMenuItem onClick={() => updateDialog(id, index)}>
+                        <Pencil />
+                        Edit
+                      </DropdownMenuItem>
+                      <DropdownMenuItem
+                        onClick={() => {
+                          const newItem = {
+                            ...item,
+                            id: crypto.randomUUID(),
+                          };
+                          setData({ [id]: [...sectionData, newItem] });
+                        }}
+                      >
+                        <Copy />
+                        Duplicate
+                      </DropdownMenuItem>
+                      <DropdownMenuItem
+                        onClick={() => toggleHiddenItem(item.id as string)}
+                      >
+                        {isItemHidden ? <Eye /> : <EyeOff />}
+                        {isItemHidden ? "Show in PDF" : "Hide from PDF"}
+                      </DropdownMenuItem>
+                      <DropdownMenuSeparator />
+                      <DropdownMenuItem
+                        className="text-red-500 focus:text-red-500"
+                        onClick={() => {
+                          setDeleteDialog({ isOpen: true, index: index });
+                        }}
+                      >
+                        <Trash className="text-red-500" />
+                        Delete
+                      </DropdownMenuItem>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
                 </div>
               </li>
             );

--- a/src/hooks/useImportJson.ts
+++ b/src/hooks/useImportJson.ts
@@ -5,7 +5,7 @@ import { ValidatedData } from "./useValidateJson";
 
 export const useImportJSON = () => {
   const [isImporting, setIsImporting] = useState(false);
-  const { setData, toggleHiddenItem } = useResume();
+  const { setData, setHiddenItemIds } = useResume();
   const { setValue } = usePdfSettings();
 
   const importJSONData = async (validatedData: ValidatedData | null) => {
@@ -31,9 +31,9 @@ export const useImportJSON = () => {
         ...resumeFields,
       });
 
-      // apply the hiddenItemIds list (if present) by toggling each one
+      // apply the hiddenItemIds list (if present)
       if (hiddenItemIds && Array.isArray(hiddenItemIds)) {
-        hiddenItemIds.forEach((id) => toggleHiddenItem(id));
+        setHiddenItemIds(hiddenItemIds);
       }
 
       // set the pdf settings to the pdf settings in the validated data

--- a/src/hooks/useImportJson.ts
+++ b/src/hooks/useImportJson.ts
@@ -5,7 +5,7 @@ import { ValidatedData } from "./useValidateJson";
 
 export const useImportJSON = () => {
   const [isImporting, setIsImporting] = useState(false);
-  const { setData } = useResume();
+  const { setData, toggleHiddenItem } = useResume();
   const { setValue } = usePdfSettings();
 
   const importJSONData = async (validatedData: ValidatedData | null) => {
@@ -23,10 +23,18 @@ export const useImportJSON = () => {
       // Simulate a delay (to be removed in future enhancement)
       await new Promise((resolve) => setTimeout(resolve, 500));
 
+      // Extract hiddenItemIds out of the resume data fields
+      const { hiddenItemIds, ...resumeFields } = validatedData;
+
       // set the resume data
       setData({
-        ...validatedData,
+        ...resumeFields,
       });
+
+      // apply the hiddenItemIds list (if present) by toggling each one
+      if (hiddenItemIds && Array.isArray(hiddenItemIds)) {
+        hiddenItemIds.forEach((id) => toggleHiddenItem(id));
+      }
 
       // set the pdf settings to the pdf settings in the validated data
       setValue("fontFamily", validatedData.pdfSettings.fontFamily);

--- a/src/hooks/useValidateJson.ts
+++ b/src/hooks/useValidateJson.ts
@@ -17,6 +17,7 @@ const cvMasterJsonSchema = cvMasterSchema.pick({
   volunteering: true,
   sectionTitles: true,
   pdfSettings: true,
+  hiddenItemIds: true,
 });
 
 export type ValidatedData = z.infer<typeof cvMasterJsonSchema>;

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -123,6 +123,9 @@ const pdfSettingsSchema = z.object({
   }),
 });
 
+// Hidden item IDs schema
+const hiddenItemIdsSchema = z.array(z.string()).optional();
+
 // Final CV Master schema
 export const cvMasterSchema = z.object({
   basics: basicsSchema,
@@ -137,4 +140,5 @@ export const cvMasterSchema = z.object({
   volunteering: z.array(z.any()), // empty array for now
   sectionTitles: sectionTitlesSchema,
   pdfSettings: pdfSettingsSchema,
+  hiddenItemIds: hiddenItemIdsSchema,
 });

--- a/src/store/useResume.ts
+++ b/src/store/useResume.ts
@@ -138,6 +138,13 @@ export const useResume = create<ResumeType>((set, get) => ({
       JSON.stringify({ hiddenItemIds: next })
     );
   },
+  setHiddenItemIds: (ids) => {
+    set({ hiddenItemIds: ids });
+    localStorage.setItem(
+      "hiddenItemIds",
+      JSON.stringify({ hiddenItemIds: ids })
+    );
+  },
 }));
 
 // Migration: ensure old users' pdfSetting includes skillsLayout

--- a/src/store/useResume.ts
+++ b/src/store/useResume.ts
@@ -86,9 +86,12 @@ const getLocalStorageData = (key: string, defaultValue = null) => {
 const localResumeData = getLocalStorageData("resumeData");
 const localPdfSetting = getLocalStorageData("pdfSetting");
 const localSectionOrder = getLocalStorageData("sectionOrder");
+const localHiddenItemIds =
+  (getLocalStorageData("hiddenItemIds") as { hiddenItemIds?: string[] })
+    ?.hiddenItemIds ?? [];
 
 // Create resume store
-export const useResume = create<ResumeType>((set) => ({
+export const useResume = create<ResumeType>((set, get) => ({
   sectionOrder: [
     "summary",
     "experience",
@@ -101,6 +104,7 @@ export const useResume = create<ResumeType>((set) => ({
     "volunteering",
   ],
   ...localSectionOrder,
+  hiddenItemIds: localHiddenItemIds,
   resumeData: {
     ...DEFAULT_RESUME_DATA,
     ...localResumeData,
@@ -121,6 +125,17 @@ export const useResume = create<ResumeType>((set) => ({
     localStorage.setItem(
       "sectionOrder",
       JSON.stringify({ sectionOrder: order })
+    );
+  },
+  toggleHiddenItem: (id) => {
+    const current = get().hiddenItemIds;
+    const next = current.includes(id)
+      ? current.filter((x) => x !== id)
+      : [...current, id];
+    set({ hiddenItemIds: next });
+    localStorage.setItem(
+      "hiddenItemIds",
+      JSON.stringify({ hiddenItemIds: next })
     );
   },
 }));

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -147,6 +147,7 @@ export interface ResumeType {
   setData: (data: Record<string, unknown>) => void;
   setSectionOrder: (order: SectionName[]) => void;
   toggleHiddenItem: (id: string) => void;
+  setHiddenItemIds: (ids: string[]) => void;
 }
 
 export interface PdfSettings {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -127,6 +127,7 @@ export type SectionName =
 // DEfine ResumeData type
 export interface ResumeType {
   sectionOrder: SectionName[];
+  hiddenItemIds: string[];
   resumeData: {
     basics: Basics;
     summary: Summary;
@@ -145,6 +146,7 @@ export interface ResumeType {
   };
   setData: (data: Record<string, unknown>) => void;
   setSectionOrder: (order: SectionName[]) => void;
+  toggleHiddenItem: (id: string) => void;
 }
 
 export interface PdfSettings {


### PR DESCRIPTION
## Overview

Two related improvements to the SectionBase item cards:

1. **Per-item "Hide from PDF"** — each item (experience entry, project, education, etc.) can be hidden from the downloaded PDF without deleting it. Useful when tailoring a CV for a specific role.
2. **Actions dropdown menu** — the 4 inline icon buttons (Edit / Duplicate / Hide / Delete) are now grouped behind a single `MoreVertical` (⋮) trigger, with a destructive style on Delete.

Also includes project documentation for the opencode agent configuration.

## What's New

### Per-item hide from PDF
- New top-level store slice `hiddenItemIds: string[]` persisted to localStorage key `hiddenItemIds`.
- `toggleHiddenItem(id)` action.
- Each preview component (`experience`, `projects`, `education`, `skills`, `languages`, `certifications`, `awards`, `volunteering`) filters out items whose ID is in `hiddenItemIds`.
- Hidden items still appear in the form (with `opacity-50`) so users can still edit or re-show them.
- Round-trips through JSON export/import (`hiddenItemIds` is an optional field in the schema).

### Actions dropdown menu
- Replaced the 4 inline icon buttons in each `SectionBase` item card with a Shadcn `DropdownMenu`.
- Menu items: Edit · Duplicate · Hide from PDF / Show in PDF · Delete (red, separated).
- Radix auto-closes the menu on item click, so the delete confirmation dialog opens cleanly.

## Files Changed

**Documentation (3 files, +2100 lines)**
- `AGENTS.md` (new)
- `.opencode/context.md` (new)
- `.opencode/skills.md` (new)

**Feature (15 files, +183 / -80)**
- `src/store/useResume.ts` — `hiddenItemIds` state + `toggleHiddenItem` action
- `src/types/types.ts` — extended `ResumeType`
- `src/components/sections/shared/SectionBase.tsx` — dropdown menu + per-item hide button
- `src/components/preview/{experience,projects,education,skills,languages,certifications,awards,volunteering}.tsx` — filter hidden items
- `src/components/core/DownloadCV.tsx` — `hiddenItemIds` in JSON export; pre-render now runs on download click
- `src/lib/schema.ts` + `src/hooks/useValidateJson.ts` — optional `hiddenItemIds` field
- `src/hooks/useImportJson.ts` — apply `hiddenItemIds` on import

## Testing

- ✅ Lint: 0 errors (15 pre-existing warnings unrelated to this PR)
- ✅ Build: TypeScript + Vite production build pass
- Manual test checklist:
  - ✅ Add 2+ items to a section
  - ✅ Click ⋮ → Hide from PDF → item gets 50% opacity in form, disappears from live preview
  - ✅ Download PDF → hidden item is not in the PDF
  - ✅ Click ⋮ → Show in PDF → item reappears
  - ✅ Click ⋮ → Delete → confirmation dialog opens
  - ✅  Export JSON → reimport → hidden items remain hidden
  - ✅ Reload page → hidden state persistso